### PR TITLE
Normalize newline handling in renderFormattedText

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ type TagPattern = {
 
 function renderFormattedText(input: string) {
   if (typeof input !== "string") input = String(input ?? "");
-  const normalizedInput = input.replace(/\\n/g, "\n");
+  const normalizedInput = input.replace(/\r\n?|\n/g, "\n");
 
   const tagSet: Set<string> = new Set();
   const tagCounts: Record<string, number> = {};
@@ -30,7 +30,7 @@ function renderFormattedText(input: string) {
   const singleColorTagRegex = /<([A-Fa-f0-9]{8})>([^<\n]*)<\/>/g;
 
   let output = "";
-  const lines = normalizedInput.split(/\r?\n/);
+  const lines = normalizedInput.split("\n");
 
   lines.forEach((line, index) => {
     let replacedLine = line;


### PR DESCRIPTION
## Summary
- Replace multiple replacements with a single regex to normalize all line endings to `\n`
- Maintain consistent line splitting on normalized newlines

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688c34443f188332a02160659bde4ee7