### PR TITLE
Normalize newline handling in renderFormattedText

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,9 @@ import * as XLSX from "xlsx";
 
 function renderFormattedText(input: string) {
   if (typeof input !== "string") input = String(input ?? "");
-  const normalizedInput = input.replace(/\\n/g, "\n");
+  const normalizedInput = input
+    .replace(/\\n/g, "\n")
+    .replace(/\r\n?/g, "\n");
 
   const tagSet: Set<string> = new Set();
   const tagCounts: Record<string, number> = {};
@@ -18,7 +20,7 @@ function renderFormattedText(input: string) {
   const singleColorTagRegex = /<([A-Fa-f0-9]{8})>([^<\n]*)<\/>/g;
 
   let output = "";
-  const lines = normalizedInput.split(/\r?\n/);
+  const lines = normalizedInput.split("\n");
 
   lines.forEach((line, index) => {
     let replacedLine = line;


### PR DESCRIPTION
## Summary
- Ensure renderFormattedText normalizes all line endings, converting `\r\n` and `\r` to `\n`.
- Split formatted text using unified `\n` separators.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c3f1d13c8833297a07a320ad6270b